### PR TITLE
Make admin roles configurable for Keystone

### DIFF
--- a/apiserver/auth/auth.go
+++ b/apiserver/auth/auth.go
@@ -19,14 +19,14 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/databus23/keystone"
 	"coriolis-logger/config"
+
+	"github.com/databus23/keystone"
 	"github.com/juju/loggo"
 	"github.com/pkg/errors"
 )
 
 const (
-	adminRoleName  = "admin"
 	AuthDetailsKey = "auth_details"
 )
 
@@ -60,6 +60,7 @@ func getKeystoneAuthenticator(cfg *config.KeystoneAuth) (Authenticator, error) {
 	auth := keystone.New(cfg.AuthURI)
 	return keystoneAuth{
 		auth: auth,
+		cfg:  cfg,
 	}, nil
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -115,7 +115,8 @@ func (t *TLSConfig) Validate() error {
 }
 
 type KeystoneAuth struct {
-	AuthURI string `toml:"auth_uri"`
+	AuthURI    string   `toml:"auth_uri"`
+	AdminRoles []string `toml:"admin_roles"`
 }
 
 func (k *KeystoneAuth) Validate() error {

--- a/testdata/config.toml
+++ b/testdata/config.toml
@@ -19,6 +19,7 @@ cors_origins = ["*"]
     [apiserver.keystone_auth]
     # The keystone auth URI
     auth_uri = "http://127.0.0.1:5000/v3"
+    admin_roles = ["admin", "Admin"]
 
     # API server TLS config
     [apiserver.tls]


### PR DESCRIPTION
This means that in the config, you need to specify a list of admin roles under the ```apiserver.keystone_auth``` config section. See example for details.