### PR TITLE
Allow only safe TLS ciphers

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -75,6 +75,7 @@ func GetAPIServer(cfg config.APIServer, hub *wsWriter.Hub, datastore common.Data
 		if err := cfg.TLSConfig.Validate(); err != nil {
 			return nil, errors.Wrap(err, "validating TLS config")
 		}
+		srv.TLSConfig = cfg.TLSConfig.Config()
 	}
 	listener, err := net.Listen("tcp", fmt.Sprintf("%s:%d", cfg.Bind, cfg.Port))
 	if err != nil {

--- a/apiserver/controllers/controllers.go
+++ b/apiserver/controllers/controllers.go
@@ -277,20 +277,20 @@ func (l *LogHandlers) DownloadLogHandler(writer http.ResponseWriter, req *http.R
 	}
 	if vars["log"] == "" {
 		writer.WriteHeader(http.StatusBadRequest)
-		fmt.Fprintf(writer, fmt.Sprintf("missing log name"))
+		fmt.Fprint(writer, "missing log name")
 	}
 	startDateStamp := req.URL.Query().Get("start_date")
 	startDate, err := timestampToTime(startDateStamp)
 	if err != nil {
 		writer.WriteHeader(http.StatusBadRequest)
-		fmt.Fprintf(writer, fmt.Sprintf("invalid start date: %q", startDateStamp))
+		fmt.Fprintf(writer, "invalid start date: %q", startDateStamp)
 	}
 
 	endDateStamp := req.URL.Query().Get("end_date")
 	endDate, err := timestampToTime(endDateStamp)
 	if err != nil {
 		writer.WriteHeader(http.StatusBadRequest)
-		fmt.Fprintf(writer, fmt.Sprintf("invalid end date: %q", endDateStamp))
+		fmt.Fprintf(writer, "invalid end date: %q", endDateStamp)
 	}
 
 	queryParams := params.QueryParams{
@@ -323,5 +323,5 @@ func (l *LogHandlers) ListLogsHandler(writer http.ResponseWriter, req *http.Requ
 		writer.WriteHeader(http.StatusInternalServerError)
 		log.Errorf("error listing logs: %v", err)
 	}
-	fmt.Fprintf(writer, string(js))
+	_, _ = writer.Write(js)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -163,7 +163,7 @@ func (a *APIServer) Validate() error {
 		}
 	}
 	if a.Port > 65535 || a.Port < 1 {
-		return fmt.Errorf("invalid port nr %q", a.Port)
+		return fmt.Errorf("invalid port nr %d", a.Port)
 	}
 	ip := net.ParseIP(a.Bind)
 	if ip == nil {

--- a/config/config.go
+++ b/config/config.go
@@ -96,6 +96,28 @@ func (t *TLSConfig) Validate() error {
 	return nil
 }
 
+func (t TLSConfig) Config() *tls.Config {
+	return &tls.Config{
+		MinVersion: tls.VersionTLS12,
+
+		CurvePreferences: []tls.CurveID{
+			tls.X25519,
+			tls.CurveP256,
+		},
+
+		PreferServerCipherSuites: true,
+
+		CipherSuites: []uint16{
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		},
+	}
+}
+
 type KeystoneAuth struct {
 	AuthURI    string   `toml:"auth_uri"`
 	AdminRoles []string `toml:"admin_roles"`
@@ -274,7 +296,7 @@ func (i *InfluxDB) TLSConfig() (*tls.Config, error) {
 		return nil, nil
 	}
 
-	cfg := &tls.Config{}
+	cfg := TLSConfig{}.Config()
 
 	var roots *x509.CertPool
 	if i.CACert != "" {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module coriolis-logger
 
-go 1.22.5
+go 1.26.3
 
 require (
 	github.com/BurntSushi/toml v1.4.0


### PR DESCRIPTION
TLS 1.2 still offers some vulnerable 64bit ciphers.
The following was found when testing with this tool: https://github.com/testssl/testssl.sh
````
Triple DES Ciphers / IDEA                         offered
 Obsoleted CBC ciphers (AES, ARIA etc.)            offered

SWEET32 (CVE-2016-2183, CVE-2016-6329)    VULNERABLE, uses 64 bit block ciphers
LUCKY13 (CVE-2013-0169), experimental     potentially VULNERABLE, uses cipher block chaining (CBC) ciphers with TLS. Check patches
````